### PR TITLE
Fixed broken issue creation

### DIFF
--- a/lib/user_update.rb
+++ b/lib/user_update.rb
@@ -13,8 +13,9 @@ module RedmineTouch
       @issue = context[:issue]
       @journal = context[:journal]
 
-      userid = @journal.user.id
-      cf = CustomField.find_by_name('Updated By')
+      userid = (@journal.nil?) ? @issue.author.id : @journal.user.id
+
+      cf = CustomField.find(:first, :conditions => ["lower(name) = ?", "Updated by".downcase])
       cv = CustomValue.where(:customized_type => "Issue", :customized_id => @issue.id, :custom_field_id => cf.id).last
       if cv.present?
         cv.update_attribute :value, userid


### PR DESCRIPTION
Got an error while creating issues on Redmine 2.4.2

```
Completed 500 Internal Server Error in 1536.1ms

NoMethodError (undefined method `user' for nil:NilClass):
  lib/redmine/hook.rb:61:in `block (2 levels) in call_hook'
  lib/redmine/hook.rb:61:in `each'
  lib/redmine/hook.rb:61:in `block in call_hook'
  lib/redmine/hook.rb:58:in `tap'
  lib/redmine/hook.rb:58:in `call_hook'
  lib/redmine/hook.rb:153:in `call_hook'
  app/controllers/issues_controller.rb:147:in `create'
```

The problem was that while creation @journal.user.id is not defined.
Also fixed problems when "Updated by" not equal to "Updated By".

Environment

```
Environment:
  Redmine version                2.4.3.stable
  Ruby version                   1.9.3-p392 (2013-02-22) [x86_64-linux]
  Rails version                  3.2.17
  Environment                    production
  Database adapter               Mysql2
SCM:
  Subversion                     1.6.12
  Mercurial                      2.5.2
  Cvs                            1.12.13
  Git                            1.8.2.2
  Filesystem                     
Redmine plugins:
  bulk_time_entry                0.5.0
  clipboard_image_paste          1.3
  question_plugin                0.3.0
  redmine_agile                  1.0.1-light1.0.1
  redmine_auto_percent           0.0.1
  redmine_banner                 0.0.8
  redmine_better_gantt_chart     0.7.0
  redmine_bugcloud               0.0.2.1
  redmine_charts2                0.2.1
  redmine_coderwall              0.2.1
  redmine_digest                 0.2.0.1
  redmine_graphs                 0.1.0
  redmine_issue_checklist        2.0.5
  redmine_issue_detailed_tabs_time 0.1.0
  redmine_lightbox               0.0.1
  redmine_logs                   0.0.5
  redmine_release_notes          1.3.0
  redmine_schedules              0.5.0
  redmine_spent_time             2.4.0
  sidebar_hide                   0.0.5
  stuff_to_do_plugin             0.4.1
```
